### PR TITLE
Convert Cantor axioms txt to formatted LaTeX

### DIFF
--- a/input/documents/cantor_absolute_infinity_1897/axioms.tex
+++ b/input/documents/cantor_absolute_infinity_1897/axioms.tex
@@ -1,95 +1,46 @@
+\documentclass[11pt]{article}
+\usepackage{geometry}
+\geometry{margin=1in}
+\setlength{\parskip}{0.8em}
+\setlength{\parindent}{0pt}
+\usepackage{hyperref}
+\usepackage{amsmath,amssymb}
+\begin{document}
 \section*{Cantor's Theory of Transfinite Numbers and the Absolute Infinite (1897) -- Formal Axiomatic Framework}
 
 \subsection*{Introduction}
-This framework summarizes Cantor's 1897 exposition using modern notation while retaining his philosophical context. Definitions and axioms reflect Cantor's terminology; theorems follow from these assumptions.
+This document formalizes Georg Cantor's 1897 exposition of transfinite numbers and the Absolute Infinite.  The formulation follows the policy in \texttt{gptlatex.txt}: all explicit definitions, axioms, and theorems from the source text are stated in a clear logical structure.  Historical remarks appear in italics.
 
 \subsection*{Definitions}
-\begin{definition}[Set or Aggregate]
-A \emph{set} (aggregate) is any well-defined collection of distinct elements. Two sets are equal iff they share exactly the same elements (Extensionality).
-\end{definition}
-%ID: Cantor.1897.Def1
-
-\begin{definition}[Equivalence and Power of Sets]
-Two sets $A$ and $B$ are \emph{equivalent} when there exists a one-to-one correspondence between their elements. The \emph{power} (cardinal number) $|A|$ of a set $A$ characterizes its size so that $|A|=|B|$ iff $A$ and $B$ are equivalent.
-\end{definition}
-%ID: Cantor.1897.Def2
-
-\begin{definition}[Transfinite Numbers -- Cardinals and Ordinals]
-A \emph{transfinite number} exceeds all finite numbers. A \emph{cardinal} measures the size of an infinite set, while an \emph{ordinal} describes the order type of a well-ordered set.
-\end{definition}
-%ID: Cantor.1897.Def3
-
-\begin{definition}[Number-Classes and Alephs]
-Ordinals are grouped into ascending \emph{number-classes}; each class corresponds to a new transfinite cardinal $\aleph_\mu$.
-\end{definition}
-%ID: Cantor.1897.Def4
-
-\begin{definition}[Absolute Infinite]
-The \emph{Absolute Infinite} $\Omega$ denotes an infinity beyond the entire transfinite sequence; it transcends all sets.
-\end{definition}
-%ID: Cantor.1897.Def5
+\begin{enumerate}
+  \item \textbf{Set or Aggregate.} A \emph{set} (aggregate) is any well-defined collection of distinct elements. Two sets are equal iff they have exactly the same elements.\label{def:set}
+  \item \textbf{Equivalence and Power of Sets.} Two sets $A$ and $B$ are \emph{equivalent} when a one-to-one correspondence exists between them. The \emph{power} (cardinality) $|A|$ measures the size of $A$, with $|A|=|B|$ iff $A$ and $B$ are equivalent.\label{def:power}
+  \item \textbf{Transfinite Numbers -- Cardinals and Ordinals.} A \emph{transfinite number} exceeds all finite numbers. A \emph{cardinal} measures the size of an infinite set; an \emph{ordinal} represents the order type of a well-ordered set.\label{def:transfinite}
+  \item \textbf{Number-Classes and Alephs.} Ordinals fall into ascending \emph{number-classes}; each class begins with a new transfinite cardinal $\aleph_{\mu}$.\label{def:numberclass}
+  \item \textbf{Absolute Infinite.} The \emph{Absolute Infinite} $\Omega$ denotes an infinity beyond the entire transfinite sequence; it is not a set but a metaphysical ideal.\label{def:absolute}
+\end{enumerate}
 
 \subsection*{Axioms}
-\begin{axiom}[Existence of Sets and Extensionality]
-There exists an infinite set (e.g. $\mathbb{N}$). Sets are determined solely by their elements: if $\forall x\,(x\in A\Leftrightarrow x\in B)$, then $A=B$.
-\end{axiom}
-%ID: Cantor.1897.Axiom1
-
-\begin{axiom}[Equinumerosity and Cardinal Comparison]
-Every set has a definite cardinal number, and any two sets can be compared in size: for sets $A,B$ exactly one of $|A|<|B|$, $|A|=|B|$, or $|A|>|B|$ holds.
-\end{axiom}
-%ID: Cantor.1897.Axiom2
-
-\begin{axiom}[Generation of Transfinite Ordinals]
-For every ordinal $\alpha$ there exists a successor $\alpha^+$, and every increasing sequence of ordinals has a limit ordinal beyond it.
-\end{axiom}
-%ID: Cantor.1897.Axiom3
-
-\begin{axiom}[Well-Ordering and Ordinal Assignment]
-Every set can be well-ordered and is therefore order-isomorphic to a unique ordinal representing its enumeration type.
-\end{axiom}
-%ID: Cantor.1897.Axiom4
-
-\begin{axiom}[Transfinite Arithmetic]
-Ordinal arithmetic (addition, multiplication, exponentiation) and cardinal arithmetic extend consistently to transfinite numbers.
-\end{axiom}
-%ID: Cantor.1897.Axiom5
-
-\begin{axiom}[Hierarchy of Infinities]
-Transfinite numbers form an endless hierarchy of number-classes indexed by the alephs $\aleph_0,\aleph_1,\ldots$ with no maximal class.
-\end{axiom}
-%ID: Cantor.1897.Axiom6
-
-\begin{axiom}[Absolute Infinity Axiom]
-No universal set or set of all ordinals exists; such totalities are treated as proper classes transcending the universe of sets.
-\end{axiom}
-%ID: Cantor.1897.Axiom7
+\begin{enumerate}
+  \item \textbf{Existence of Sets and Extensionality.} There exists an infinite set (for example $\mathbb{N}$). Sets are determined solely by their elements: if $\forall x\,(x\in A \Leftrightarrow x\in B)$ then $A=B$.\label{ax:existence}
+  \item \textbf{Equinumerosity and Cardinal Comparison.} Every set has a definite cardinal number, and any two sets can be compared in size: for sets $A,B$ exactly one of $|A|<|B|$, $|A|=|B|$, or $|A|>|B|$ holds.\label{ax:compare}
+  \item \textbf{Generation of Transfinite Ordinals.} For every ordinal $\alpha$ there exists a successor $\alpha^+$, and every increasing sequence of ordinals has a limit ordinal beyond it.\label{ax:generate}
+  \item \textbf{Well-Ordering and Ordinal Assignment.} Every set can be well-ordered and is therefore order-isomorphic to a unique ordinal representing its enumeration type.\label{ax:wellorder}
+  \item \textbf{Transfinite Arithmetic.} Ordinal arithmetic (addition, multiplication, exponentiation) and cardinal arithmetic extend consistently to transfinite numbers.\label{ax:arithmetic}
+  \item \textbf{Hierarchy of Infinities.} Transfinite numbers form an endless hierarchy of number-classes indexed by the alephs $\aleph_0,\aleph_1,\ldots$ with no maximal class.\label{ax:hierarchy}
+  \item \textbf{Absolute Infinity Axiom.} No universal set or set of all ordinals exists; such totalities are treated as proper classes transcending the universe of sets.\label{ax:absolute}
+\end{enumerate}
 
 \subsection*{Theorems}
-\begin{theorem}[Countable Sets and $\aleph_0$]
-The natural numbers $\mathbb{N}$ have the smallest infinite cardinality $\aleph_0$. Any countable union of countable sets is countable.
-\end{theorem}
-%ID: Cantor.1897.Thm1
-
-\begin{theorem}[Uncountability of the Continuum]
-The real numbers $\mathbb{R}$ have cardinality $2^{\aleph_0}$, strictly greater than $\aleph_0$; hence $\mathbb{R}$ is uncountable.
-\end{theorem}
-%ID: Cantor.1897.Thm2
-
-\begin{theorem}[Cantor's Power-Set Theorem]
-For any set $A$, the power-set $\mathcal{P}(A)$ has strictly larger cardinality than $A$: $|\mathcal{P}(A)|>|A|$.
-\end{theorem}
-%ID: Cantor.1897.Thm3
-
-\begin{theorem}[No Maximum Transfinite Number]
-There is no largest ordinal or cardinal. For every ordinal $\alpha$ there exists a larger ordinal $\alpha^+$, and for each cardinal $\kappa$ there is a larger cardinal.
-\end{theorem}
-%ID: Cantor.1897.Thm4
-
-\begin{theorem}[Ordinal Arithmetic Properties]
-Transfinite ordinal arithmetic is associative and distributive but not commutative; cardinal arithmetic for infinite cardinals is commutative.
-\end{theorem}
-%ID: Cantor.1897.Thm5
+\begin{enumerate}
+  \item \textbf{Countable Sets and $\aleph_0$.} From Definitions~\ref{def:set}--\ref{def:transfinite} and Axioms~\ref{ax:existence},\ref{ax:arithmetic} we conclude that $\mathbb{N}$ has the smallest infinite cardinality $\aleph_0$, and any countable union of countable sets is countable.\label{thm:countable}
+  \item \textbf{Uncountability of the Continuum.} Using Axioms~\ref{ax:compare} and~\ref{ax:arithmetic}, the real numbers $\mathbb{R}$ have cardinality $2^{\aleph_0}>\aleph_0$ and are therefore uncountable.\label{thm:continuum}
+  \item \textbf{Cantor's Power-Set Theorem.} (from Axiom~\ref{ax:arithmetic}) For any set $A$, the power-set $\mathcal{P}(A)$ has strictly larger cardinality than $A$: $|\mathcal{P}(A)|>|A|$.\label{thm:powerset}
+  \item \textbf{No Maximum Transfinite Number.} From Axioms~\ref{ax:generate} and~\ref{ax:hierarchy}, there is no largest ordinal or cardinal; for every $\alpha$ a larger $\alpha^+$ exists, and for each cardinal $\kappa$ a larger one follows.\label{thm:nomax}
+  \item \textbf{Ordinal Arithmetic Properties.} Based on Axiom~\ref{ax:arithmetic}, transfinite ordinal arithmetic is associative and distributive but not commutative; for infinite cardinals the arithmetic is commutative.\label{thm:arith}
+\end{enumerate}
 
 \subsection*{Commentary}
-Cantor's axioms align with modern set theory (ZFC) augmented by proper classes. The Absolute Infinite represents a metaphysical ideal rather than a set.
+\textit{Cantor's axioms align with modern set theory (ZFC) augmented by proper classes. The Absolute Infinite serves as a philosophical horizon rather than an element of the formal universe.}
+
+\end{document}


### PR DESCRIPTION
## Summary
- regenerate `axioms.tex` for Cantor's 1897 work using gptlatex policy
- enumerate definitions, axioms, and theorems with references

## Testing
- `git status --short`